### PR TITLE
1.0.2 hotfix 1

### DIFF
--- a/Runtime/Components/FractalNoiseGeneratorComponent.cs
+++ b/Runtime/Components/FractalNoiseGeneratorComponent.cs
@@ -88,7 +88,9 @@ namespace SadSapphicGames.NoiseGenerators
         /// </summary>
         private void DisableInputTextureGeneration()
         {
-
+            if(inputTextureAssets == null) {
+                inputTextureAssets = new List<Texture>();
+            }
             useTextureAssets = true;
         }
         private void EnableInputTextureGeneration()


### PR DESCRIPTION
adds a missing line of code to initialize input asset list when switching to using assets over texture generation